### PR TITLE
Fix: avoid programming custom devices

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Version 1.1.1
 
-- Fix: avoid programming custom devices
+- Fix: avoid programming custom devices #34
 
 ## Version 1.1.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 1.1.1
+
+- Fix: avoid programming custom devices
+
 ## Version 1.1.0
 
 - Added support for custom device and custom firmware #23
@@ -6,3 +10,4 @@
 ## Version 1.0.0
 
 - Initial public release
+

--- a/index.jsx
+++ b/index.jsx
@@ -79,6 +79,7 @@ export default {
                     fwIdAddress: 0x6000,
                 },
             },
+            allowCustomDevice: true,
         },
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-dtm",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Direct Test Mode",
   "displayName": "Direct Test Mode",
   "repository": {


### PR DESCRIPTION
This PR adds the missing configuration option to avoid programming custom devices.
