### PR TITLE
Allow 2Mb phy for unknown devices

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 1.1.2
+
+- Allow 2Mb phy for unknown devices #36
+
 ## Version 1.1.1
 
 - Fix: avoid programming custom devices #34

--- a/lib/utils/boards.js
+++ b/lib/utils/boards.js
@@ -1,27 +1,25 @@
 import { DTM } from 'nrf-dtm-js/src/DTM.js';
 import * as Constants from './constants';
 
-const nRF52832 = {
-    phy: {},
-    txPower: [-40, -20, -16, -12, -8, -4, 0, 2, 3, 4],
-};
-nRF52832.phy.PHY_LE_1M = DTM.DTM_PARAMETER.PHY_LE_1M;
-nRF52832.phy.PHY_LE_2M = DTM.DTM_PARAMETER.PHY_LE_2M;
-
-
-const nRF52840 = {
-    phy: {},
-    txPower: [-40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8],
-};
-nRF52840.phy.PHY_LE_1M = DTM.DTM_PARAMETER.PHY_LE_1M;
-nRF52840.phy.PHY_LE_2M = DTM.DTM_PARAMETER.PHY_LE_2M;
-nRF52840.phy.PHY_LE_CODED_S8 = DTM.DTM_PARAMETER.PHY_LE_CODED_S8;
-nRF52840.phy.PHY_LE_CODED_S2 = DTM.DTM_PARAMETER.PHY_LE_CODED_S2;
-
 const defaultDevice = {
-    phy: {},
+    phy: {
+        PHY_LE_1M: DTM.DTM_PARAMETER.PHY_LE_1M,
+        PHY_LE_2M: DTM.DTM_PARAMETER.PHY_LE_2M,
+        PHY_LE_CODED_S8: DTM.DTM_PARAMETER.PHY_LE_CODED_S8,
+        PHY_LE_CODED_S2: DTM.DTM_PARAMETER.PHY_LE_CODED_S2,
+    },
     txPower: Constants.dbmValues,
 };
+
+const nRF52832 = {
+    phy: {
+        PHY_LE_1M: DTM.DTM_PARAMETER.PHY_LE_1M,
+        PHY_LE_2M: DTM.DTM_PARAMETER.PHY_LE_2M,
+    },
+    txPower: Constants.dbmValues.filter(tx => tx <= 4),
+};
+
+const nRF52840 = { ...defaultDevice };
 
 function fromPCA(board) {
     switch (board) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-dtm",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Direct Test Mode",
   "displayName": "Direct Test Mode",
   "repository": {


### PR DESCRIPTION
This PR allows unknown devices to use all DTM parameters rather than restricting them.