### PR TITLE
Convert Packet length component to slider

### DIFF
--- a/src/SidePanel/OtherSettingsView.jsx
+++ b/src/SidePanel/OtherSettingsView.jsx
@@ -60,11 +60,12 @@ const phyTypeView = (boardType, phy, onPhyUpdated, isRunning) => {
         <Form.Group controlId="formTimeoutSelect">
             <Form.Label>Physical layer</Form.Label>
             <Dropdown
-                items={items}
                 title={DTM_PHY_STRING[phy]}
                 id="dropdown-variants-phy-type"
                 disabled={isRunning}
-            />
+            >
+                {items}
+            </Dropdown>
         </Form.Group>
     );
 };

--- a/src/SidePanel/PacketView.jsx
+++ b/src/SidePanel/PacketView.jsx
@@ -41,7 +41,7 @@ import React from 'react';
 import FormLabel from 'react-bootstrap/FormLabel';
 import { useDispatch, useSelector } from 'react-redux';
 import { DTM, DTM_PKT_STRING } from 'nrf-dtm-js/src/DTM';
-import { Group, NumberInlineInput, Slider } from 'pc-nrfconnect-shared';
+import { NumberInlineInput, Slider } from 'pc-nrfconnect-shared';
 
 import {
     bitpatternChanged,
@@ -50,29 +50,29 @@ import {
     lengthChanged,
 } from '../reducers/settingsReducer';
 import { getIsRunning } from '../reducers/testReducer';
-import MyDropdownButton from './dropdown/Dropdown';
+import Dropdown from './dropdown/Dropdown';
 import DropdownItem from './dropdown/DropdownItem';
 
 import 'react-rangeslider/lib/index.css';
 
 const VENDOR_PAYLOAD_LENGTH = 1;
 
-const packetTypeView = (
+const PacketTypeView = (
     bitpatternUpdated,
     lengthUpdated,
-    pkgType,
+    selectedPkgType,
     isRunning,
     isVendorPayload
 ) => {
     const items = Object.keys(DTM.DTM_PKT)
         .filter(key => key !== 'DEFAULT')
-        .map((key, packageType) => (
+        .map((key, pkgType) => (
             <DropdownItem
                 key={key}
-                title={DTM_PKT_STRING[packageType]}
+                title={DTM_PKT_STRING[pkgType]}
                 onSelect={() => {
-                    bitpatternUpdated(packageType);
-                    if (isVendorPayload(packageType)) {
+                    bitpatternUpdated(pkgType);
+                    if (isVendorPayload(pkgType)) {
                         lengthUpdated(VENDOR_PAYLOAD_LENGTH);
                     }
                 }}
@@ -82,16 +82,17 @@ const packetTypeView = (
     return (
         <>
             <FormLabel>Packet type</FormLabel>
-            <MyDropdownButton
-                title={DTM_PKT_STRING[pkgType]}
-                items={[items]}
+            <Dropdown
+                title={DTM_PKT_STRING[selectedPkgType]}
                 disabled={isRunning}
-            />
+            >
+                {items}
+            </Dropdown>
         </>
     );
 };
 
-const packetLengthView = (currentLength, changedFunc, isRunning) => {
+const PacketLengthView = (currentLength, changedFunc, isRunning) => {
     const range = { min: 1, max: 255 };
     return (
         <>
@@ -132,22 +133,22 @@ const PacketView = () => {
     return (
         <>
             <div className="app-sidepanel-component-inputbox">
-                {packetTypeView(
-                    value => dispatch(bitpatternChanged(value)),
-                    lengthChangedAction,
-                    pkgType,
-                    isRunning,
-                    isVendorPayload
-                )}
+                <PacketTypeView
+                    value={value => dispatch(bitpatternChanged(value))}
+                    lengthChangedAction={lengthChangedAction}
+                    selectedPkgType={pkgType}
+                    isRunning={isRunning}
+                    isVendorPayload={isVendorPayload}
+                />
             </div>
 
             {!isVendorPayload(pkgType) && (
                 <div className="app-sidepanel-component-inputbox">
-                    {packetLengthView(
-                        packetLength,
-                        lengthChangedAction,
-                        isRunning
-                    )}
+                    <PacketLengthView
+                        packetLength={packetLength}
+                        lengthChangedAction={lengthChangedAction}
+                        isRunning={isRunning}
+                    />
                 </div>
             )}
         </>

--- a/src/SidePanel/dropdown/Dropdown.tsx
+++ b/src/SidePanel/dropdown/Dropdown.tsx
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useRef } from 'react';
+import React, { FC, useRef } from 'react';
 
 import chevron from './chevron.svg';
 import useDetectClick from './useDetectClick';
@@ -43,12 +43,11 @@ import './Dropdown.scss';
 
 interface DropdownProps {
     title: string;
-    items?: JSX.Element[];
     id?: string;
     disabled?: boolean;
 }
 
-const Dropdown = ({ title, items, id, disabled }: DropdownProps) => {
+const Dropdown: FC<DropdownProps> = ({ title, id, disabled, children }) => {
     const dropdownRef = useRef(null);
     const [isActive, setIsActive] = useDetectClick(dropdownRef, false);
     const onClick = () => setIsActive(!isActive);
@@ -73,7 +72,7 @@ const Dropdown = ({ title, items, id, disabled }: DropdownProps) => {
                     isActive ? 'active' : 'inactive'
                 }`}
             >
-                {items}
+                {children}
             </div>
         </div>
     );


### PR DESCRIPTION
### Choosing packet length is now done with slider component

![image](https://user-images.githubusercontent.com/34618612/120623684-3c269c80-c460-11eb-8f17-41b50e405052.png)

### When selecting packet type === Constant Carrier the packet length slider is removed and the packet length is set to 1

![image](https://user-images.githubusercontent.com/34618612/120623812-5b252e80-c460-11eb-80dd-9792613673cd.png)


