### PR TITLE
Remove lint init

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,6 @@ steps:
 - script: |
     set -o errexit -o pipefail
     npm ci
-    npm run lint-init
     npm run lint
     npm run build
     npm pack

--- a/package.json
+++ b/package.json
@@ -1,59 +1,59 @@
 {
-  "name": "pc-nrfconnect-dtm",
-  "version": "2.0.1",
-  "description": "Direct Test Mode",
-  "displayName": "Direct Test Mode",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-dtm.git"
-  },
-  "author": "Nordic Semiconductor ASA",
-  "license": "SEE LICENSE IN LICENSE",
-  "engines": {
-    "nrfconnect": "^3.8.0"
-  },
-  "main": "dist/bundle.js",
-  "files": [
-    "dist/",
-    "firmware/*.hex",
-    "resources/icon.*",
-    "icon.png",
-    "LICENSE"
-  ],
-  "scripts": {
-    "dev": "nrfconnect-scripts build-watch",
-    "webpack": "nrfconnect-scripts build-dev",
-    "build": "nrfconnect-scripts build-prod",
-    "nordic-publish": "nrfconnect-scripts nordic-publish",
-    "lint": "nrfconnect-scripts lint src",
-    "lintfix": "nrfconnect-scripts lint --fix src",
-    "test": "nrfconnect-scripts test",
-    "test-watch": "nrfconnect-scripts test --watch",
-    "clean": "npm run clean-dist && npm run clean-modules",
-    "clean-dist": "rimraf dist",
-    "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
-  },
-  "devDependencies": {
-    "@nordicsemiconductor/nrf-device-lib-js": "^0.3.14",
-    "@reduxjs/toolkit": "^1.5.1",
-    "@testing-library/react": "^11.2.7",
-    "@testing-library/user-event": "^13.1.9",
-    "@types/chart.js": "^2.9.32",
-    "@types/react": "^17.0.37",
-    "@types/react-dom": "^17.0.6",
-    "@types/react-redux": "^7.1.16",
-    "chart.js": "^2.9.4",
-    "chartjs-plugin-datalabels": "^1.0.0",
-    "nrf-dtm-js": "github:NordicPlayground/nrf-dtm-js",
-    "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.10.0",
-    "react": "16.13.1",
-    "react-chartjs-2": "^2.7.6",
-    "react-dom": "16.13.1",
-    "react-redux": "7.2.0"
-  },
-  "dependencies": {},
-  "eslintConfig": {
-    "extends": "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
-  },
-  "prettier": "./node_modules/pc-nrfconnect-shared/config/prettier.config.js"
+    "name": "pc-nrfconnect-dtm",
+    "version": "2.0.1",
+    "description": "Direct Test Mode",
+    "displayName": "Direct Test Mode",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-dtm.git"
+    },
+    "author": "Nordic Semiconductor ASA",
+    "license": "SEE LICENSE IN LICENSE",
+    "engines": {
+        "nrfconnect": "^3.8.0"
+    },
+    "main": "dist/bundle.js",
+    "files": [
+        "dist/",
+        "firmware/*.hex",
+        "resources/icon.*",
+        "icon.png",
+        "LICENSE"
+    ],
+    "scripts": {
+        "dev": "nrfconnect-scripts build-watch",
+        "webpack": "nrfconnect-scripts build-dev",
+        "build": "nrfconnect-scripts build-prod",
+        "nordic-publish": "nrfconnect-scripts nordic-publish",
+        "lint": "nrfconnect-scripts lint src",
+        "lintfix": "nrfconnect-scripts lint --fix src",
+        "test": "nrfconnect-scripts test",
+        "test-watch": "nrfconnect-scripts test --watch",
+        "clean": "npm run clean-dist && npm run clean-modules",
+        "clean-dist": "rimraf dist",
+        "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
+    },
+    "devDependencies": {
+        "@nordicsemiconductor/nrf-device-lib-js": "^0.3.14",
+        "@reduxjs/toolkit": "^1.5.1",
+        "@testing-library/react": "^11.2.7",
+        "@testing-library/user-event": "^13.1.9",
+        "@types/chart.js": "^2.9.32",
+        "@types/react": "^17.0.37",
+        "@types/react-dom": "^17.0.6",
+        "@types/react-redux": "^7.1.16",
+        "chart.js": "^2.9.4",
+        "chartjs-plugin-datalabels": "^1.0.0",
+        "nrf-dtm-js": "github:NordicPlayground/nrf-dtm-js",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.10.0",
+        "react": "16.13.1",
+        "react-chartjs-2": "^2.7.6",
+        "react-dom": "16.13.1",
+        "react-redux": "7.2.0"
+    },
+    "dependencies": {},
+    "eslintConfig": {
+        "extends": "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
+    },
+    "prettier": "./node_modules/pc-nrfconnect-shared/config/prettier.config.js"
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "build": "nrfconnect-scripts build-prod",
     "nordic-publish": "nrfconnect-scripts nordic-publish",
     "lint": "nrfconnect-scripts lint src",
-    "lint-init": "nrfconnect-scripts lint-init",
     "lintfix": "nrfconnect-scripts lint --fix src",
     "test": "nrfconnect-scripts test",
     "test-watch": "nrfconnect-scripts test --watch",


### PR DESCRIPTION
`lint-init` is not needed anymore. Remove the last reference to it.