### PR TITLE
fix: sort channels correctly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
--   Sweep mode would in some casese not use the selected channels.
+-   Sweep mode in some cases wasn't using the selected channels.
 
 ## 2.4.0 - 2024-04-09
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 2.4.1 - Unreleased
+
+### Fixed
+
+-   Sweep mode would in some casese not use the selected channels.
+
 ## 2.4.0 - 2024-04-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-dtm",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "displayName": "Direct Test Mode",
     "description": "RF PHY testing of Bluetooth Low Energy devices",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-dtm",

--- a/src/actions/testActions.ts
+++ b/src/actions/testActions.ts
@@ -141,7 +141,7 @@ export const startTests =
         const singleChannelIndexed = bleChannelsValues.indexOf(singleChannel);
         const channelRangeIndexed = channelRange
             .map(channel => bleChannelsValues.indexOf(channel))
-            .sort();
+            .sort((a, b) => a - b);
 
         const testMode = paneName(getState());
 


### PR DESCRIPTION
sort() without an argument only sorts based on the first ASCII value This would result in [20, 5].sort() => [20, 5]
