### PR TITLE
doc: rename app and other edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# nRF Connect Direct Test Mode
+# Direct Test Mode app
 
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-dtm?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=19&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-nRF Connect Direct Test Mode is an application for performing RF PHY testing of
-Bluetooth Low Energy devices with the Bluetooth-specified Direct Test Mode. See
+The Direct Test Mode app in nRF Connect for Desktop is an application for performing RF PHY testing
+of Bluetooth® Low Energy devices with the Bluetooth-specified Direct Test Mode. See
 the
 [Bluetooth Core specification](https://www.bluetooth.com/specifications/specs/core-specification-5-3/)
 (volume 6, part F) for more information about the Direct Test Mode
@@ -14,7 +14,7 @@ specification.
 
 ## Installation
 
-nRF Connect Direct Test Mode is installed from nRF Connect from Desktop. For
+The Direct Test Mode app is installed from nRF Connect from Desktop. For
 detailed steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
@@ -22,7 +22,7 @@ in the nRF Connect from Desktop documentation.
 ## Documentation
 
 Read the
-[nRF Connect Direct Test Mode](https://docs.nordicsemi.com/bundle/nrf-connect-direct-test-mode/page/index.html)
+[Direct Test Mode app](https://docs.nordicsemi.com/bundle/nrf-connect-direct-test-mode/page/index.html)
 official documentation.
 
 ## Development

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,8 +1,8 @@
-# nRF Connect Direct Test Mode
+# {{app_name}}
 
-nRF Connect Direct Test Mode is an application that provides a graphical UI for the Direct Test Mode (DTM) commands through 2-wire UART. The DTM is a Bluetooth test framework used for performing RF PHY testing of Bluetooth Low Energy devices and ensuring interoperability of the Bluetooth devices.
+The {{app_name}} in nRF Connect for Desktop provides a graphical UI for the Direct Test Mode (DTM) commands through 2-wire UART. The DTM is a Bluetooth® test framework used for performing RF PHY testing of Bluetooth Low Energy devices and ensuring interoperability of the Bluetooth devices.
 
-You can use nRF Connect Direct Test Mode to control the following features of the radio:
+You can use the {{app_name}} to control the following features of the radio:
 
 - Set transmission power and receiver sensitivity
 - Set frequency offset and drift
@@ -13,11 +13,11 @@ You can use nRF Connect Direct Test Mode to control the following features of th
 See the [Bluetooth Core specification](https://www.bluetooth.com/specifications/specs/core-specification-5-3/) (volume 6, part F) for more information about the DTM requirements.
 
 !!! tip "Important"
-      nRF Connect Direct Test Mode cannot be used as a testing or certification tool. This is because it only provides a graphical wrapper around DTM commands for the Upper Tester. For verification using both the Upper Tester and the Lower Tester, you need an external tester equipment. For example, in case of the [Direct Test Mode Bluetooth sample](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/direct_test_mode/README.html), this can be the Anritsu MT8852 or similar, in which case you obtain the following configuration:
+      The {{app_name}} cannot be used as a testing or certification tool. This is because it only provides a graphical wrapper around DTM commands for the Upper Tester. For verification using both the Upper Tester and the Lower Tester, you need an external tester equipment. For example, in case of the [Direct Test Mode Bluetooth sample](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/direct_test_mode/README.html), this can be the Anritsu MT8852 or similar, in which case you obtain the following configuration:
 
       ![Testing setup for the Direct Test Mode Bluetooth sample](./screenshots/bt_dtm_dut.svg "Testing setup for the Direct Test Mode Bluetooth sample")
 
-nRF Connect Direct Test Mode is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) (v4.4.1 or later).
+The {{app_name}} is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) (v4.4.1 or later).
 
 ## Supported devices
 

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,3 @@
-# Installing Direct Test Mode app
+# Installing the {{app_name}}
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -1,8 +1,8 @@
 # Overview and user interface
 
-After starting nRF Connect Direct Test Mode, the main application window is displayed.
+After starting the {{app_name}}, the main application window is displayed.
 
-![nRF Connect Direct Test Mode window](./screenshots/dtm_overview.png "nRF Connect Direct Test Mode window")
+![{{app_name}} window](./screenshots/dtm_overview.png "{{app_name}} window")
 
 The available options and information change after you **Select Device**.
 

--- a/doc/docs/using_dtm.md
+++ b/doc/docs/using_dtm.md
@@ -1,9 +1,9 @@
 # Configuring and using the application
 
-In nRF Connect Direct Test Mode, you can control the reception and transmission characteristics of the Bluetooth connection through 2-wire UART, in accordance with the [Bluetooth Core specification](https://www.bluetooth.com/specifications/specs/core-specification-5-3/) (volume 6, part F).
+In the {{app_name}}, you can control the reception and transmission characteristics of the Bluetooth connection through 2-wire UART, in accordance with the [Bluetooth Core specification](https://www.bluetooth.com/specifications/specs/core-specification-5-3/) (volume 6, part F).
 
 !!! info "Tip"
-     If you are using an nRF52840 DK or an nRF52833 DK, nRF Connect Direct Test Mode will automatically detect when started if the connected device has the right firmware programmed and will offer to program it.
+     If you are using an nRF52840 DK or an nRF52833 DK, the {{app_name}} will automatically detect when started if the connected device has the right firmware programmed and will offer to program it.
 
 It is recommended to use two devices for both scenarios:
 
@@ -11,7 +11,7 @@ It is recommended to use two devices for both scenarios:
   For example, you can use the [Direct Test Mode Bluetooth sample](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/direct_test_mode/README.html) from the nRF Connect SDK.
 
     !!! note "Note"
-          The [Direct Test Mode Bluetooth sample](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/direct_test_mode/README.html) supports two Device Under Test communication protocols: 2-wire UART and experimental HCI UART interface. nRF Connect Direct Test Mode only supports the 2-wire UART.
+          The [Direct Test Mode Bluetooth sample](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/direct_test_mode/README.html) supports two Device Under Test communication protocols: 2-wire UART and experimental HCI UART interface. The {{app_name}} only supports the 2-wire UART.
 
 * **Device 2**: One device programmed with the firmware conformant to the Bluetooth specification.</br>
   This can also be an off-the-shelf product certified for Bluetooth 5.3.

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect Direct Test Mode documentation
+site_name: Direct Test Mode app documentation
 site_url:
 use_directory_urls: false
 
@@ -30,7 +30,7 @@ extra_css:
   - stylesheets/style.css
 
 copyright:
-  Copyright &copy; 2023
+  Copyright &copy; 2020-2024
 
 markdown_extensions:
   - abbr
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4
@@ -56,10 +53,11 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: Direct Test Mode app
 
 nav:
   - Home: index.md
-  - Installing Direct Test Mode app: installing.md
+  - Installing the Direct Test Mode app: installing.md
   - Overview and user interface: overview.md
   - Configuring and using the application: using_dtm.md
   - Revision history: revision_history.md

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-direct-test-mode
-booktitle=nRF Connect Direct Test Mode
-shortdesc=Documentation for the nRF Connect Direct Test Mode application.
+booktitle=Direct Test Mode
+shortdesc=Documentation for the Direct Test Mode application.


### PR DESCRIPTION
Renamed app to not feature `nRF Connect` in the name. Updated copyright year.
Removed unused extensions.
Added app name abbreviation.
NCD-1066.
