### PR TITLE
Feat/baudrate deps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
-## 2.4.3 - Unreleased
+## 2.5.0 - Unreleased
+
+### Added
+
+-   Drop-down menu for changing the baud rate in order to use custom firmwares.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-dtm",
-    "version": "2.4.2",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
     "packages": {
         "": {
             "name": "pc-nrfconnect-dtm",
-            "version": "2.4.2",
+            "version": "2.5.0",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^200.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^204.0.0",
                 "@testing-library/user-event": "^13.1.9",
                 "chart.js": "^4.0.1",
                 "chartjs-plugin-datalabels": "2.2.0",
@@ -2453,9 +2453,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "200.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-200.0.0.tgz",
-            "integrity": "sha512-r6YvsoEC/g6w8gIubJJlCgjrjSLJ0Sy+6UK/MS7FX8iv/cUW+Yia+zYItQyWnMm4es+kIHZRwliJ5DlYUbIQ+A==",
+            "version": "204.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-204.0.0.tgz",
+            "integrity": "sha512-5Fyne5lAAj6yebYfdt2ZzG4iR7GXiCWz/gCsBUsl9nVvdTjTFM8cbo/PB/AVYqfwlssmDzz1XvZhdLICkwvIHw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",
@@ -2545,7 +2545,7 @@
                 "semver": "7.3.8",
                 "serialport": "^12.0.0",
                 "shasum": "1.0.2",
-                "systeminformation": "5.17.12",
+                "systeminformation": "^5.25.11",
                 "tailwindcss": "3.3.2",
                 "tree-kill-promise": "^3.0.14",
                 "ts-node": "10.9.1",
@@ -13868,7 +13868,7 @@
         },
         "node_modules/nrf-dtm-js": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/NordicPlayground/nrf-dtm-js.git#290f1929496bf9a246b18e44ec302b639f8348a0",
+            "resolved": "git+ssh://git@github.com/NordicPlayground/nrf-dtm-js.git#78b86247ecfa796bd6c94ec4a87a63399997e98b",
             "dev": true,
             "license": "Propietary",
             "dependencies": {
@@ -18608,10 +18608,11 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.17.12",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.17.12.tgz",
-            "integrity": "sha512-I3pfMW2vue53u+X08BNxaJieaHkRoMMKjWetY9lbYJeWFaeWPO6P4FkNc4XOCX8F9vbQ0HqQ25RJoz3U/B7liw==",
+            "version": "5.25.11",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
+            "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==",
             "dev": true,
+            "license": "MIT",
             "os": [
                 "darwin",
                 "linux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-dtm",
-    "version": "2.4.3",
+    "version": "2.5.0",
     "displayName": "Direct Test Mode",
     "description": "RF PHY testing of Bluetooth Low Energy devices",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-dtm",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prepare": "husky install"
     },
     "devDependencies": {
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^200.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^204.0.0",
         "@testing-library/user-event": "^13.1.9",
         "chart.js": "^4.0.1",
         "chartjs-plugin-datalabels": "2.2.0",


### PR DESCRIPTION
Forgot to update the dependencies and add changelog entry.

@greg-fer this adds a dropdown menu to choose the baudrate between running tests. We still only ship firmwares for supported devices with the default baudrate.
![Screenshot from 2025-04-07 10-09-22](https://github.com/user-attachments/assets/4a8a91bf-dfdb-4531-95c8-ae63607fa64b)
