### PR TITLE
fix: use correct min and max channels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,11 @@
 -   Prebuilt firmware.
 -   Removed filtering available dBm values per device.
 
+### Fixed
+
+-   Issue where the value set in the **Channel Range** slider in the sweep mode
+    would not be correctly communicated to the device.
+
 ## 2.5.3 - 2025-08-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-dtm",
-    "version": "2.5.3",
+    "version": "3.0.0",
     "displayName": "Direct Test Mode",
     "description": "RF PHY testing of Bluetooth Low Energy devices",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-dtm",

--- a/src/actions/testActions.ts
+++ b/src/actions/testActions.ts
@@ -108,6 +108,7 @@ export const startTests =
             dispatch(clearCommunicationErrorWarning());
             logger.info('Starting test');
 
+            const indexes = channelRange.map(v => bleChannelsValues.indexOf(v));
             let testPromise;
             if (
                 testMode === 'transmitter' &&
@@ -126,8 +127,8 @@ export const startTests =
                 testPromise = dtm.sweepTransmitterTest(
                     bitpattern,
                     length,
-                    bleChannelsValues.indexOf(Math.min(...channelRange)),
-                    bleChannelsValues.indexOf(Math.max(...channelRange)),
+                    Math.min(...indexes),
+                    Math.max(...indexes),
                     sweepTime,
                     timeoutms
                 );
@@ -155,8 +156,8 @@ export const startTests =
                 testPromise = dtm.sweepReceiverTest(
                     bitpattern,
                     length,
-                    bleChannelsValues.indexOf(Math.min(...channelRange)),
-                    bleChannelsValues.indexOf(Math.max(...channelRange)),
+                    Math.min(...indexes),
+                    Math.max(...indexes),
                     sweepTime,
                     timeoutms
                 );


### PR DESCRIPTION
Previuosly this got the min of an unsorted/explicitly non-sorted array and then the index

Now it actually gets the correct min and max values
