### PR TITLE
chore: point workflows and package URLs to nordicsemi org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
     build:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/build-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/build-app.yml@main

--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     create-doc-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
         with:
             bundle-name: nrf-connect-direct-test-mode

--- a/.github/workflows/docs-publish-dev.yml
+++ b/.github/workflows/docs-publish-dev.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-direct-test-mode
             release-type: dev

--- a/.github/workflows/docs-publish-prod.yml
+++ b/.github/workflows/docs-publish-prod.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-direct-test-mode
             release-type: prod

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
     check_labels:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/labels.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/labels.yml@main
         secrets: inherit

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: latest (internal)
         secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: ${{ inputs.source }}
             ref: ${{ inputs.ref }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ official documentation.
 ## Development
 
 See the
-[app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/)
+[app development](https://nordicsemi.github.io/pc-nrfconnect-docs/)
 pages for details on how to develop apps for the nRF Connect for Desktop
 framework.
 
@@ -39,7 +39,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[infos on contributing](https://nordicsemi.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Direct Test Mode app
 
-[![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-dtm?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=19&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
 The Direct Test Mode app in nRF Connect for Desktop is an application for
@@ -27,8 +26,7 @@ official documentation.
 
 ## Development
 
-See the
-[app development](https://nordicsemi.github.io/pc-nrfconnect-docs/)
+See the [app development](https://nordicsemi.github.io/pc-nrfconnect-docs/)
 pages for details on how to develop apps for the nRF Connect for Desktop
 framework.
 

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -34,5 +34,5 @@ The Direct Test Mode app can be used with devices programmed with firmware compa
 
 ## Application source code
 
-The code of the application is open source and [available on GitHub](https://github.com/NordicSemiconductor/pc-nrfconnect-dtm).
+The code of the application is open source and [available on GitHub](https://github.com/nordicsemi/pc-nrfconnect-dtm).
 Feel free to fork the repository and clone it for secondary development or feature contributions.

--- a/doc/docs/revision_history.yml
+++ b/doc/docs/revision_history.yml
@@ -19,4 +19,4 @@ sections:
   - "Added the [Application source code](./index.md#application-source-code) section on the [Home](./index.md) page."
 - name: April 2024
   entries:
-  - "First release, for the [v2.3.1](https://github.com/NordicSemiconductor/pc-nrfconnect-dtm/blob/main/Changelog.md) of the application."
+  - "First release, for the [v2.3.1](https://github.com/nordicsemi/pc-nrfconnect-dtm/blob/main/Changelog.md) of the application."

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "version": "3.1.1",
     "displayName": "Direct Test Mode",
     "description": "RF PHY testing of Bluetooth Low Energy devices",
-    "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-dtm",
+    "homepage": "https://github.com/nordicsemi/pc-nrfconnect-dtm",
     "repository": {
         "type": "git",
-        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-dtm.git"
+        "url": "https://github.com/nordicsemi/pc-nrfconnect-dtm.git"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Update reusable workflow references and repository homepage/URL from NordicSemiconductor to nordicsemi.

## Summary

Updates all reusable workflow `uses:` paths from `NordicSemiconductor/pc-nrfconnect-shared` to `nordicsemi/pc-nrfconnect-shared` to match the enterprise organization naming.

`package.json` `homepage` and `repository.url` point at the canonical **nordicsemi** org (not the former NordicSemiconductor naming).

## Notes

No functional workflow logic changes; only the repository path in composite/reusable workflow references, plus `package.json` metadata for the official GitHub location.