### PR TITLE
Update documentation links

### DIFF
--- a/src/DocumentationSection.tsx
+++ b/src/DocumentationSection.tsx
@@ -11,7 +11,7 @@ const DocumentationSections = [
     <DocumentationSection
         key="techdocs"
         linkLabel="Open documentation"
-        link="https://docs.nordicsemi.com/bundle/nrf-connect-direct-test-mode/page/index.html"
+        link="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-dtm/index.html"
     >
         Visit TechDocs for official documentation of the app.
     </DocumentationSection>,


### PR DESCRIPTION
https://docs.nordicsemi.com/bundle/nrf-connect-direct-test-mode is the outdated bundle which is not updated anymore. Correct is now to link to https://docs.nordicsemi.com/bundle/swtools_docs.

